### PR TITLE
Enable spriteatlas compression

### DIFF
--- a/Plugins/SimpleFileBrowser/Sprites/SimpleFileBrowserSpriteAtlas.spriteatlas
+++ b/Plugins/SimpleFileBrowser/Sprites/SimpleFileBrowserSpriteAtlas.spriteatlas
@@ -21,14 +21,14 @@ SpriteAtlas:
       crunchedCompression: 0
       sRGB: 1
     platformSettings:
-    - serializedVersion: 2
+    - serializedVersion: 3
       m_BuildTarget: DefaultTexturePlatform
       m_MaxTextureSize: 2048
       m_ResizeAlgorithm: 0
       m_TextureFormat: -1
-      m_TextureCompression: 0
-      m_CompressionQuality: 50
-      m_CrunchedCompression: 0
+      m_TextureCompression: 1
+      m_CompressionQuality: 90
+      m_CrunchedCompression: 1
       m_AllowsAlphaSplitting: 0
       m_Overridden: 0
       m_AndroidETC2FallbackOverride: 0


### PR DESCRIPTION
important for mobile platforms to reduce build size:
![image](https://github.com/yasirkula/UnitySimpleFileBrowser/assets/44395959/cc723fc7-bd74-484f-86e8-6be12fa49c1f)
->
![image](https://github.com/yasirkula/UnitySimpleFileBrowser/assets/44395959/3142e11d-0667-4d17-a4b5-cad8aa1f689f)
